### PR TITLE
GRAVITYAI-1251 Update Agenta backend and UI to store and display reasoning for custom metric scores

### DIFF
--- a/agenta-backend/agenta_backend/models/api/api_models.py
+++ b/agenta-backend/agenta_backend/models/api/api_models.py
@@ -32,6 +32,7 @@ class Result(BaseModel):
     type: str
     value: Optional[Any] = None
     error: Optional[Error] = None
+    reason: Optional[str] = None
 
 
 class GetConfigResponse(BaseModel):

--- a/agenta-backend/agenta_backend/models/db_models.py
+++ b/agenta-backend/agenta_backend/models/db_models.py
@@ -187,6 +187,7 @@ class Result(BaseModel):
     type: str
     value: Optional[Any] = None
     error: Optional[Error] = None
+    reason: Optional[str] = None
 
 
 class InvokationResult(BaseModel):

--- a/agenta-backend/agenta_backend/services/evaluators_service.py
+++ b/agenta-backend/agenta_backend/services/evaluators_service.py
@@ -145,7 +145,8 @@ async def auto_webhook_test(
                         message="Error during Auto Webhook evaluation; Webhook returned an invalid score. Score must be between 0 and 1",
                     ),
                 )
-            return Result(type="number", value=score)
+            reason = response_data.get("reason", None)
+            return Result(type="number", value=score, reason=reason)
     except httpx.HTTPError as e:
         return Result(
             type="error",

--- a/agenta-web/src/components/pages/evaluations/evaluationScenarios/EvaluationScenarios.tsx
+++ b/agenta-web/src/components/pages/evaluations/evaluationScenarios/EvaluationScenarios.tsx
@@ -132,7 +132,6 @@ const EvaluationScenarios: React.FC<Props> = () => {
                     )
                 },
                 autoHeaderHeight: true,
-                field: `results`,
                 ...getFilterParams("text"),
                 cellRenderer: ResultRenderer,
                 cellRendererParams: {
@@ -142,6 +141,27 @@ const EvaluationScenarios: React.FC<Props> = () => {
                     return params.data?.results[index].result.value
                 },
             })
+            if (scenarios.some(scenario => scenario.results[index].result.reason !== null)) {
+                colDefs.push({
+                    headerName: config?.name + "-reason",
+                    headerComponent: (props: any) => {
+                        const evaluator = evaluators.find((item) => item.key === config?.evaluator_key)!
+                        return (
+                            <AgCustomHeader {...props}>
+                                <Space direction="vertical" style={{padding: "0.5rem 0"}}>
+                                    <span>{config.name + "-reason"}</span>
+                                    <Tag color={evaluator?.color}>{evaluator?.name}</Tag>
+                                </Space>
+                            </AgCustomHeader>
+                        )
+                    },
+                    autoHeaderHeight: true,
+                    cellRenderer: (params: any) => LongTextCellRenderer(params),
+                    valueGetter: (params) => {
+                        return params.data?.results[index].result.reason
+                    },
+                })
+            }
         })
         colDefs.push({
             flex: 1,

--- a/agenta-web/src/lib/Types.ts
+++ b/agenta-web/src/lib/Types.ts
@@ -366,6 +366,7 @@ export interface TypedValue {
     type: ValueTypeOptions
     value: ValueType
     error: null | EvaluationError
+    reason: null | string
 }
 
 export enum EvaluationStatus {


### PR DESCRIPTION
This PR:
- Adds the functionality for agenta-backend to store the reasoning from our LLM as a judge custom webhook metrics.
- Supports displaying the reasoning in the UI (see image below) and also returning the reasoning in our CSV files.
- Note: a new column is added in the UI only if there is at least one reason given for that metric.


![Screenshot 2024-07-30 at 2 42 05 PM](https://github.com/user-attachments/assets/6aadcd18-53d1-4924-b511-99c466149099)
